### PR TITLE
chore(deps): ignore Angular & tooling major updates; restrict to security/minor/patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,14 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      - dependency-name: "@angular/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@angular-devkit/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "zone.js"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "rxjs"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
This PR updates the Dependabot configuration to ignore major version upgrades for Angular, Angular Devkit, and related tooling.  
We will handle major framework upgrades manually to ensure smooth migrations.  
Dependabot will now only open pull requests for security, minor, and patch updates.
